### PR TITLE
Revise leaf reflector-udp-port

### DIFF
--- a/src/yang/ietf-twamp.yang
+++ b/src/yang/ietf-twamp.yang
@@ -1255,7 +1255,9 @@ module ietf-twamp {
         }
 
         leaf reflector-udp-port {
-          type dynamic-port-number;
+          type uint32 {
+            range "862|49152..65535";
+	  }
           description
             "The destination UDP port number used in the
             TWAMP-Test (UDP) test packets belonging to this

--- a/src/yang/ietf-twamp.yang
+++ b/src/yang/ietf-twamp.yang
@@ -679,16 +679,17 @@ module ietf-twamp {
           }
 
           leaf reflector-udp-port {
-            type dynamic-port-number;
+            type uint32 {
+              range "862|49152..65535";
+            }
             description
               "This parameter defines the UDP port number that
               will be used by the Session-Reflector for
-              this TWAMP-Test session. The number is restricted
-              to the dynamic port range and is to be placed in
+              this TWAMP-Test session. The default number is within
+              the dynamic port range and is to be placed in
               the Receiver Port field of the Request-TW-Session
-              message.";
-          }
-
+              message. The new well-known port number MAY be used.";
+		      }
           leaf timeout {
             type uint64;
             units seconds;


### PR DESCRIPTION
Trying to add the new well-known port as a possible choice, but even this (without the default statement I was using previously) doesn't pass the yanglint check:

err : Failed to resolve list key "sender-udp-port
reflector-ip reflector-udp-port". (/ietf-twamp:twamp/session-reflector/test-session)
err : Module "ietf-twamp" parsing failed.

(So, not ready to merge!)